### PR TITLE
fix: detect support for workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 test-results/
 dist/
 dist-worker/
+.vscode

--- a/benchmark/opfs.bench.spec.ts
+++ b/benchmark/opfs.bench.spec.ts
@@ -1,6 +1,6 @@
 import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
-import { OPFSBlockstore } from '../src/index'
+import { OPFSBlockstore } from '../src/index.ts'
 
 describe('OPFSBlockstore benchmark', () => {
   it('large writes and reads', async function () {

--- a/benchmark/opfs.bench.spec.ts
+++ b/benchmark/opfs.bench.spec.ts
@@ -40,25 +40,21 @@ describe('OPFSBlockstore benchmark', () => {
 
     const results = []
 
-    try {
-      results.push(await timed('put chunked bytes', async () => {
-        for (let i = 0; i < iterations; i++) {
-          const cid = await makeCid(i)
-          cids.push(cid)
-          await store.put(cid, chunkedBytes(i))
-        }
-      }))
+    results.push(await timed('put chunked bytes', async () => {
+      for (let i = 0; i < iterations; i++) {
+        const cid = await makeCid(i)
+        cids.push(cid)
+        await store.put(cid, chunkedBytes(i))
+      }
+    }))
 
-      results.push(await timed('get and drain bytes', async () => {
-        for (const cid of cids) {
-          for await (const _chunk of store.get(cid)) {
-            // drain stream
-          }
+    results.push(await timed('get and drain bytes', async () => {
+      for (const cid of cids) {
+        for await (const _chunk of store.get(cid)) {
+          // drain stream
         }
-      }))
-    } finally {
-      await store.deleteAll()
-    }
+      }
+    }))
 
     console.table(results)
   })

--- a/src-worker/opfs.worker.ts
+++ b/src-worker/opfs.worker.ts
@@ -1,9 +1,9 @@
 // src/opfs-worker.ts
-import { OPFSWebWorkerFS } from '../src/web-worker-fs.ts'
+import { OPFSWebWorker } from '../src/web-worker-fs.ts'
 import { toArrayBuffer, toUint8Array } from '../src/utils.ts'
 import { CID } from 'multiformats/cid'
 
-let store: OPFSWebWorkerFS | undefined
+let store: OPFSWebWorker | undefined
 
 // Event listener with a synchronous handler
 self.addEventListener('message', (event) => {
@@ -122,7 +122,7 @@ async function handleMessage (event: MessageEvent): Promise<void> {
 
 async function handleOpen (id: any, params: any): Promise<void> {
   const { path, getManyConcurrency, putManyConcurrency, deleteManyConcurrency } = params
-  store = new OPFSWebWorkerFS(path)
+  store = new OPFSWebWorker(path)
   await store.open()
 
   if (getManyConcurrency !== undefined) {

--- a/src-worker/opfs.worker.ts
+++ b/src-worker/opfs.worker.ts
@@ -1,6 +1,6 @@
 // src/opfs-worker.ts
-import { OPFSWebWorkerFS } from '../src/web-worker-fs'
-import { toArrayBuffer, toUint8Array } from '../src/utils'
+import { OPFSWebWorkerFS } from '../src/web-worker-fs.ts'
+import { toArrayBuffer, toUint8Array } from '../src/utils.ts'
 import { CID } from 'multiformats/cid'
 
 let store: OPFSWebWorkerFS | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // src/index.ts
-import { OPFSBlockstore } from './opfs-blockstore'
-import { workerScript } from './opfs-worker'
-import type { OPFSBlockstoreInit } from './opfs-blockstore'
+import { OPFSBlockstore } from './opfs-blockstore.ts'
+import { workerScript } from './opfs-worker.ts'
+import type { OPFSBlockstoreInit } from './opfs-blockstore.ts'
 
 export { type OPFSBlockstoreInit, OPFSBlockstore, workerScript }

--- a/src/main-thread-fs.ts
+++ b/src/main-thread-fs.ts
@@ -5,9 +5,9 @@ import { DeleteFailedError, GetFailedError, NotFoundError, OpenFailedError, PutF
 import map from 'it-map'
 import parallelBatch from 'it-parallel-batch'
 import { CID } from 'multiformats/cid'
-import { asByteStream, throwIfAborted, toArrayBuffer, toUint8Array } from './utils'
-import type { OPFSBlockstoreInit } from '.'
-import type { AbortOptions, AwaitIterable } from './utils'
+import { asByteStream, throwIfAborted, toArrayBuffer, toUint8Array } from './utils.ts'
+import type { OPFSBlockstoreInit } from './index.ts'
+import type { AbortOptions, AwaitIterable } from './utils.ts'
 import type { Blockstore, InputPair, Pair } from 'interface-blockstore'
 
 export class OPFSMainThreadFS implements Blockstore {

--- a/src/opfs-blockstore.ts
+++ b/src/opfs-blockstore.ts
@@ -6,11 +6,10 @@
  * that uses a web worker to do all the operations.
  */
 
-import map from 'it-map'
-import parallelBatch from 'it-parallel-batch'
 import { CID } from 'multiformats/cid'
-import { workerScript } from './opfs-worker.ts'
-import { asByteStream, throwIfAborted, toArrayBuffer, toUint8Array } from './utils.ts'
+import { OPFSMainThreadBlockstore } from './opfs-main-thread.ts'
+import { OPFSWebWorkerBlockstore } from './opfs-web-worker.ts'
+import { isClosable, isOpenable, supportsWorkers } from './utils.ts'
 import type { AbortOptions, AwaitIterable } from './utils.ts'
 import type { Blockstore, InputPair, Pair } from 'interface-blockstore'
 
@@ -32,58 +31,27 @@ export interface OPFSBlockstoreInit {
    * default: 50
    */
   deleteManyConcurrency?: number
+
+  /**
+   * By default all OPFS operations will take place synchronously in a
+   * WebWorker, pass `false` here to run operations asynchronously in the main
+   * thread.
+   *
+   * In environments Where WebWorkers are not supported this defaults to
+   * `false`, otherwise `true`.
+   */
+  useWebWorker?: boolean
 }
 
 export class OPFSBlockstore implements Blockstore {
-  private readonly path: string
-  private readonly worker!: Worker
-  private readonly _putManyConcurrency: number
-  private readonly _getManyConcurrency: number
-  private readonly _deleteManyConcurrency: number
-  private requestId = 0
-  private readonly workerPendingRequests = new Map<number, { resolve(value: any): void, reject(reason?: any): void }>()
+  private readonly impl: Blockstore
 
   constructor (path: string, opts?: OPFSBlockstoreInit) {
-    this.path = path
-    this._putManyConcurrency = opts?.putManyConcurrency ?? 1
-    this._getManyConcurrency = opts?.getManyConcurrency ?? 50
-    this._deleteManyConcurrency = opts?.deleteManyConcurrency ?? 1
-
-    try {
-      const blob = new Blob([workerScript], { type: 'text/javascript' })
-      const blobUrl = globalThis.URL.createObjectURL(blob)
-      this.worker = new Worker(blobUrl)
-    } catch (e: any) {
-      throw new Error(`Failed to instantiate web worker ${e}`)
+    if (opts?.useWebWorker === false || !supportsWorkers()) {
+      this.impl = new OPFSMainThreadBlockstore(path, opts)
+    } else {
+      this.impl = new OPFSWebWorkerBlockstore(path, opts)
     }
-
-    this.worker.onmessage = (event) => {
-      // console.log(this.workerPendingRequests)
-      const { id, result, error, errorName, errorMessage, errorStack } = event.data
-      const request = this.workerPendingRequests.get(id)
-      if (request === undefined) {
-        throw new Error(`Unknown request ID: ${id}`)
-      }
-
-      this.workerPendingRequests.delete(id)
-
-      if (error === undefined) {
-        request.resolve(result)
-        return
-      }
-
-      // eslint-disable-next-line no-console
-      console.log('worker request rejected', id, result, errorName)
-      request.reject({ name: errorName, message: errorMessage, stack: errorStack })
-    }
-  }
-
-  private async callWorker (method: string, params: any, transfer: Transferable[] = []): Promise<any> {
-    return new Promise((resolve, reject) => {
-      const id = this.requestId++
-      this.workerPendingRequests.set(id, { resolve, reject })
-      this.worker.postMessage({ id, method, params }, transfer)
-    })
   }
 
   /**
@@ -92,19 +60,18 @@ export class OPFSBlockstore implements Blockstore {
    * @throws {OpenFailedError}
    */
   async open (): Promise<void> {
-    await this.callWorker('open', {
-      path: this.path,
-      getManyConcurrency: this._getManyConcurrency,
-      putManyConcurrency: this._putManyConcurrency,
-      deleteManyConcurrency: this._deleteManyConcurrency
-    })
+    if (isOpenable(this.impl)) {
+      await this.impl.open()
+    }
   }
 
   /**
    * Closes the blockstore.
    */
-  close (): void {
-    this.worker.terminate()
+  async close (): Promise<void> {
+    if (isClosable(this.impl)) {
+      await this.impl.close()
+    }
   }
 
   /**
@@ -114,12 +81,7 @@ export class OPFSBlockstore implements Blockstore {
    * @throws {QuotaExceededError}
    */
   async put (key: CID, val: Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array>, options?: AbortOptions): Promise<CID> {
-    throwIfAborted(options)
-
-    const buffer = toArrayBuffer(await toUint8Array(val), val instanceof Uint8Array)
-    await this.callWorker('put', { key: key.toString(), value: buffer }, [buffer])
-
-    return key
+    return this.impl.put(key, val, options)
   }
 
   /**
@@ -129,18 +91,7 @@ export class OPFSBlockstore implements Blockstore {
    * @throws {QuotaExceededError}
    */
   async * putMany (source: AwaitIterable<InputPair>, options?: AbortOptions): AsyncGenerator<CID> {
-    throwIfAborted(options)
-
-    yield * parallelBatch(
-      map(source, ({ cid, bytes }) => {
-        return async () => {
-          await this.put(cid, bytes, options)
-
-          return cid
-        }
-      }),
-      this._putManyConcurrency
-    )
+    yield * this.impl.putMany(source, options)
   }
 
   /**
@@ -148,10 +99,8 @@ export class OPFSBlockstore implements Blockstore {
    *
    * @throws {NotFoundError}
    */
-  get (key: CID, options?: AbortOptions): AsyncGenerator<Uint8Array> {
-    throwIfAborted(options)
-
-    return asByteStream(this.callWorker('get', { key: key.toString() }).then((bytes) => new Uint8Array(bytes)))
+  async * get (key: CID, options?: AbortOptions): AsyncGenerator<Uint8Array> {
+    yield * this.impl.get(key, options)
   }
 
   /**
@@ -160,41 +109,14 @@ export class OPFSBlockstore implements Blockstore {
    * @throws {NotFoundError}
    */
   async * getMany (source: AwaitIterable<CID>, options?: AbortOptions): AsyncGenerator<Pair> {
-    throwIfAborted(options)
-
-    yield * parallelBatch(
-      map(source, key => {
-        return async () => {
-          return {
-            cid: key,
-            bytes: this.get(key, options)
-          }
-        }
-      }),
-      this.getManyConcurrency
-    )
+    yield * this.impl.getMany(source, options)
   }
 
   /**
    * Gets all blocks.
    */
   async * getAll (options?: AbortOptions): AsyncGenerator<Pair> {
-    throwIfAborted(options)
-
-    const keys: string[] = await this.callWorker('ls', {})
-
-    yield * parallelBatch(
-      map(keys, key => {
-        return async () => {
-          const cid = CID.parse(key)
-          return {
-            cid,
-            bytes: this.get(cid, options)
-          }
-        }
-      }),
-      this.getManyConcurrency
-    )
+    yield * this.impl.getAll(options)
   }
 
   /**
@@ -203,9 +125,7 @@ export class OPFSBlockstore implements Blockstore {
    * @throws {DeleteFailedError}
    */
   async delete (key: CID, options?: AbortOptions): Promise<void> {
-    throwIfAborted(options)
-
-    return this.callWorker('delete', { key: key.toString() })
+    await this.impl.delete(key, options)
   }
 
   /**
@@ -214,25 +134,7 @@ export class OPFSBlockstore implements Blockstore {
    * @throws {DeleteFailedError}
    */
   async * deleteMany (source: AwaitIterable<CID>, options?: AbortOptions): AsyncGenerator<CID> {
-    throwIfAborted(options)
-
-    yield * parallelBatch(
-      map(source, key => {
-        return async () => {
-          await this.delete(key, options)
-
-          return key
-        }
-      }),
-      this.deleteManyConcurrency
-    )
-  }
-
-  /**
-   * Deletes all blocks.
-   */
-  async deleteAll (): Promise<void> {
-    return this.callWorker('deleteAll', { path: this.path })
+    yield * this.impl.deleteMany(source, options)
   }
 
   /**
@@ -241,20 +143,6 @@ export class OPFSBlockstore implements Blockstore {
    * @returns A boolean indicating existence.
    */
   async has (key: CID, options?: AbortOptions): Promise<boolean> {
-    throwIfAborted(options)
-
-    return this.callWorker('has', { key: key.toString() })
-  }
-
-  public get putManyConcurrency (): number {
-    return this._putManyConcurrency
-  }
-
-  public get getManyConcurrency (): number {
-    return this._getManyConcurrency
-  }
-
-  public get deleteManyConcurrency (): number {
-    return this._deleteManyConcurrency
+    return this.impl.has(key, options)
   }
 }

--- a/src/opfs-blockstore.ts
+++ b/src/opfs-blockstore.ts
@@ -9,9 +9,9 @@
 import map from 'it-map'
 import parallelBatch from 'it-parallel-batch'
 import { CID } from 'multiformats/cid'
-import { workerScript } from './opfs-worker'
-import { asByteStream, throwIfAborted, toArrayBuffer, toUint8Array } from './utils'
-import type { AbortOptions, AwaitIterable } from './utils'
+import { workerScript } from './opfs-worker.ts'
+import { asByteStream, throwIfAborted, toArrayBuffer, toUint8Array } from './utils.ts'
+import type { AbortOptions, AwaitIterable } from './utils.ts'
 import type { Blockstore, InputPair, Pair } from 'interface-blockstore'
 
 export interface OPFSBlockstoreInit {

--- a/src/opfs-main-thread.ts
+++ b/src/opfs-main-thread.ts
@@ -5,12 +5,12 @@ import { DeleteFailedError, GetFailedError, NotFoundError, OpenFailedError, PutF
 import map from 'it-map'
 import parallelBatch from 'it-parallel-batch'
 import { CID } from 'multiformats/cid'
-import { asByteStream, throwIfAborted, toArrayBuffer, toUint8Array } from './utils.ts'
+import { asByteStream, throwIfAborted, toArrayBuffer } from './utils.ts'
 import type { OPFSBlockstoreInit } from './index.ts'
 import type { AbortOptions, AwaitIterable } from './utils.ts'
 import type { Blockstore, InputPair, Pair } from 'interface-blockstore'
 
-export class OPFSMainThreadFS implements Blockstore {
+export class OPFSMainThreadBlockstore implements Blockstore {
   private readonly putManyConcurrency: number
   private readonly getManyConcurrency: number
   private readonly deleteManyConcurrency: number
@@ -38,7 +38,7 @@ export class OPFSMainThreadFS implements Blockstore {
     }
   }
 
-  close (): void {
+  async close (): Promise<void> {
     // noop
   }
 
@@ -53,13 +53,23 @@ export class OPFSMainThreadFS implements Blockstore {
 
     let writable: FileSystemWritableFileStream | undefined
 
+    if (val instanceof Uint8Array) {
+      val = [val]
+    }
+
     try {
       const fileHandle = await this.bsRoot.getFileHandle(key.toString(), { create: true })
       writable = await fileHandle.createWritable()
-      await writable.write(toArrayBuffer(await toUint8Array(val)))
+
+      for await (const buf of val) {
+        options?.signal?.throwIfAborted()
+        await writable.write(toArrayBuffer(buf))
+        options?.signal?.throwIfAborted()
+      }
+
       await writable.close()
     } catch (err) {
-      await writable?.abort()
+      await writable?.abort(err)
       throw new PutFailedError(String(err))
     }
 
@@ -85,19 +95,20 @@ export class OPFSMainThreadFS implements Blockstore {
     )
   }
 
-  get (key: CID, options?: AbortOptions): AsyncGenerator<Uint8Array> {
-    throwIfAborted(options)
+  async * get (key: CID, options?: AbortOptions): AsyncGenerator<Uint8Array> {
+    options?.signal?.throwIfAborted()
 
-    return asByteStream(this.getBytes(key))
-  }
-
-  private async getBytes (key: CID): Promise<Uint8Array> {
     try {
-      const fileHandle = await this.bsRoot.getFileHandle(key.toString(), { create: false })
+      const fileHandle = await this.bsRoot.getFileHandle(key.toString(), {
+        create: false
+      })
       const file = await fileHandle.getFile()
-      await file.arrayBuffer()
 
-      return new Uint8Array(await file.arrayBuffer())
+      for await (const buf of file.stream()) {
+        options?.signal?.throwIfAborted()
+        yield buf
+        options?.signal?.throwIfAborted()
+      }
     } catch (err) {
       throw new NotFoundError(String(err))
     }
@@ -160,7 +171,7 @@ export class OPFSMainThreadFS implements Blockstore {
 
     try {
       await this.bsRoot.getFileHandle(key.toString(), { create: false })
-    } catch (e) {
+    } catch {
       return false
     }
 

--- a/src/opfs-web-worker.ts
+++ b/src/opfs-web-worker.ts
@@ -1,0 +1,241 @@
+// src/opfs-blockstore.ts
+/**
+ * @packageDocumentation
+ *
+ * OPFSBlockstore is Origin Private File System blockstore for use in browsers,
+ * that uses a web worker to do all the operations.
+ */
+
+import map from 'it-map'
+import parallelBatch from 'it-parallel-batch'
+import { CID } from 'multiformats/cid'
+import { workerScript } from './opfs-worker.ts'
+import { asByteStream, throwIfAborted, toArrayBuffer, toUint8Array } from './utils.ts'
+import type { OPFSBlockstoreInit } from './opfs-blockstore.ts'
+import type { AbortOptions, AwaitIterable } from './utils.ts'
+import type { Blockstore, InputPair, Pair } from 'interface-blockstore'
+
+export class OPFSWebWorkerBlockstore implements Blockstore {
+  private readonly path: string
+  private readonly worker!: Worker
+  private readonly _putManyConcurrency: number
+  private readonly _getManyConcurrency: number
+  private readonly _deleteManyConcurrency: number
+  private requestId = 0
+  private readonly workerPendingRequests = new Map<number, { resolve(value: any): void, reject(reason?: any): void }>()
+
+  constructor (path: string, opts?: OPFSBlockstoreInit) {
+    this.path = path
+    this._putManyConcurrency = opts?.putManyConcurrency ?? 1
+    this._getManyConcurrency = opts?.getManyConcurrency ?? 50
+    this._deleteManyConcurrency = opts?.deleteManyConcurrency ?? 1
+
+    try {
+      const blob = new Blob([workerScript], { type: 'text/javascript' })
+      const blobUrl = globalThis.URL.createObjectURL(blob)
+      this.worker = new Worker(blobUrl)
+    } catch (e: any) {
+      throw new Error(`Failed to instantiate web worker ${e}`)
+    }
+
+    this.worker.onmessage = (event) => {
+      // console.log(this.workerPendingRequests)
+      const { id, result, error, errorName, errorMessage, errorStack } = event.data
+      const request = this.workerPendingRequests.get(id)
+      if (request === undefined) {
+        throw new Error(`Unknown request ID: ${id}`)
+      }
+
+      this.workerPendingRequests.delete(id)
+
+      if (error === undefined) {
+        request.resolve(result)
+        return
+      }
+
+      // eslint-disable-next-line no-console
+      console.log('worker request rejected', id, result, errorName)
+      request.reject({ name: errorName, message: errorMessage, stack: errorStack })
+    }
+  }
+
+  private async callWorker (method: string, params: any, transfer: Transferable[] = []): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const id = this.requestId++
+      this.workerPendingRequests.set(id, { resolve, reject })
+      this.worker.postMessage({ id, method, params }, transfer)
+    })
+  }
+
+  /**
+   * Opens the blockstore.
+   *
+   * @throws {OpenFailedError}
+   */
+  async open (): Promise<void> {
+    await this.callWorker('open', {
+      path: this.path,
+      getManyConcurrency: this._getManyConcurrency,
+      putManyConcurrency: this._putManyConcurrency,
+      deleteManyConcurrency: this._deleteManyConcurrency
+    })
+  }
+
+  /**
+   * Closes the blockstore.
+   */
+  async close (): Promise<void> {
+    this.worker.terminate()
+  }
+
+  /**
+   * Puts a block by its CID.
+   *
+   * @throws {PutFailedError}
+   * @throws {QuotaExceededError}
+   */
+  async put (key: CID, val: Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array>, options?: AbortOptions): Promise<CID> {
+    throwIfAborted(options)
+
+    const buffer = toArrayBuffer(await toUint8Array(val), val instanceof Uint8Array)
+    await this.callWorker('put', { key: key.toString(), value: buffer }, [buffer])
+
+    return key
+  }
+
+  /**
+   * Puts multiple blocks.
+   *
+   * @throws {PutFailedError}
+   * @throws {QuotaExceededError}
+   */
+  async * putMany (source: AwaitIterable<InputPair>, options?: AbortOptions): AsyncGenerator<CID> {
+    throwIfAborted(options)
+
+    yield * parallelBatch(
+      map(source, ({ cid, bytes }) => {
+        return async () => {
+          await this.put(cid, bytes, options)
+
+          return cid
+        }
+      }),
+      this._putManyConcurrency
+    )
+  }
+
+  /**
+   * Gets a block by its CID.
+   *
+   * @throws {NotFoundError}
+   */
+  get (key: CID, options?: AbortOptions): AsyncGenerator<Uint8Array> {
+    throwIfAborted(options)
+
+    return asByteStream(this.callWorker('get', { key: key.toString() }).then((bytes) => new Uint8Array(bytes)))
+  }
+
+  /**
+   * Gets multiple blocks.
+   *
+   * @throws {NotFoundError}
+   */
+  async * getMany (source: AwaitIterable<CID>, options?: AbortOptions): AsyncGenerator<Pair> {
+    throwIfAborted(options)
+
+    yield * parallelBatch(
+      map(source, key => {
+        return async () => {
+          return {
+            cid: key,
+            bytes: this.get(key, options)
+          }
+        }
+      }),
+      this.getManyConcurrency
+    )
+  }
+
+  /**
+   * Gets all blocks.
+   */
+  async * getAll (options?: AbortOptions): AsyncGenerator<Pair> {
+    throwIfAborted(options)
+
+    const keys: string[] = await this.callWorker('ls', {})
+
+    yield * parallelBatch(
+      map(keys, key => {
+        return async () => {
+          const cid = CID.parse(key)
+          return {
+            cid,
+            bytes: this.get(cid, options)
+          }
+        }
+      }),
+      this.getManyConcurrency
+    )
+  }
+
+  /**
+   * Deletes a block by its CID.
+   *
+   * @throws {DeleteFailedError}
+   */
+  async delete (key: CID, options?: AbortOptions): Promise<void> {
+    throwIfAborted(options)
+
+    return this.callWorker('delete', { key: key.toString() })
+  }
+
+  /**
+   * Deletes multiple blocks.
+   *
+   * @throws {DeleteFailedError}
+   */
+  async * deleteMany (source: AwaitIterable<CID>, options?: AbortOptions): AsyncGenerator<CID> {
+    throwIfAborted(options)
+
+    yield * parallelBatch(
+      map(source, key => {
+        return async () => {
+          await this.delete(key, options)
+
+          return key
+        }
+      }),
+      this.deleteManyConcurrency
+    )
+  }
+
+  /**
+   * Deletes all blocks.
+   */
+  async deleteAll (): Promise<void> {
+    return this.callWorker('deleteAll', { path: this.path })
+  }
+
+  /**
+   * Checks if a block exists by its original CID.
+   *
+   * @returns A boolean indicating existence.
+   */
+  async has (key: CID, options?: AbortOptions): Promise<boolean> {
+    throwIfAborted(options)
+
+    return this.callWorker('has', { key: key.toString() })
+  }
+
+  public get putManyConcurrency (): number {
+    return this._putManyConcurrency
+  }
+
+  public get getManyConcurrency (): number {
+    return this._getManyConcurrency
+  }
+
+  public get deleteManyConcurrency (): number {
+    return this._deleteManyConcurrency
+  }
+}

--- a/src/opfs-worker.ts
+++ b/src/opfs-worker.ts
@@ -916,4 +916,4 @@ async function Se(e, t) {
 		result: null
 	});
 }
-//#endregion`;
+//#endregion`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,3 +49,15 @@ export function toArrayBuffer (bytes: Uint8Array, forceCopy: boolean = false): A
 export async function * asByteStream (bytes: Uint8Array | Promise<Uint8Array>): AsyncGenerator<Uint8Array> {
   yield await bytes
 }
+
+export function supportsWorkers (): boolean {
+  return Boolean(globalThis.Worker)
+}
+
+export function isOpenable <T> (obj: any): obj is T & { open(): void | Promise<void> } {
+  return typeof obj.open === 'function'
+}
+
+export function isClosable <T> (obj: any): obj is T & { close(): void | Promise<void> } {
+  return typeof obj.close === 'function'
+}

--- a/src/web-worker-fs.ts
+++ b/src/web-worker-fs.ts
@@ -9,7 +9,7 @@ import type { OPFSBlockstoreInit } from './index.ts'
 import type { AbortOptions, AwaitIterable } from './utils.ts'
 import type { Blockstore, InputPair, Pair } from 'interface-blockstore'
 
-export class OPFSWebWorkerFS implements Blockstore {
+export class OPFSWebWorker implements Blockstore {
   private putManyConcurrency: number
   private getManyConcurrency: number
   private deleteManyConcurrency: number

--- a/src/web-worker-fs.ts
+++ b/src/web-worker-fs.ts
@@ -4,9 +4,9 @@ import { DeleteFailedError, GetFailedError, NotFoundError, OpenFailedError, PutF
 import map from 'it-map'
 import parallelBatch from 'it-parallel-batch'
 import { CID } from 'multiformats/cid'
-import { asByteStream, throwIfAborted, toArrayBuffer, toUint8Array } from './utils'
-import type { OPFSBlockstoreInit } from '.'
-import type { AbortOptions, AwaitIterable } from './utils'
+import { asByteStream, throwIfAborted, toArrayBuffer, toUint8Array } from './utils.ts'
+import type { OPFSBlockstoreInit } from './index.ts'
+import type { AbortOptions, AwaitIterable } from './utils.ts'
 import type { Blockstore, InputPair, Pair } from 'interface-blockstore'
 
 export class OPFSWebWorkerFS implements Blockstore {

--- a/test/blockstore-tests.spec.ts
+++ b/test/blockstore-tests.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'aegir/chai'
 import { interfaceBlockstoreTests } from 'interface-blockstore-tests'
-import { OPFSBlockstore } from '../src/index'
+import { OPFSBlockstore } from '../src/index.ts'
 
 // const pwOpts = (process.env.PW_OPTIONS != null) ? JSON.parse(process.env.PW_OPTIONS) : {}
 

--- a/test/blockstore-tests.spec.ts
+++ b/test/blockstore-tests.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from 'aegir/chai'
 import { interfaceBlockstoreTests } from 'interface-blockstore-tests'
 import { OPFSBlockstore } from '../src/index.ts'
+import { OPFSMainThreadBlockstore } from '../src/opfs-main-thread.ts'
+import { OPFSWebWorkerBlockstore } from '../src/opfs-web-worker.ts'
 
 // const pwOpts = (process.env.PW_OPTIONS != null) ? JSON.parse(process.env.PW_OPTIONS) : {}
 
@@ -10,13 +12,52 @@ describe('interface-blockstore (OPFS Blockstore)', () => {
     try {
       interfaceBlockstoreTests({
         async setup () {
-          const store = new OPFSBlockstore('bs')
+          const store = new OPFSBlockstore('bs-' + Date.now())
           await store.open()
           return store
         },
         async teardown (store: OPFSBlockstore) {
-          await store.deleteAll()
-          store.close()
+          await store.close()
+        }
+      })
+      expect(true).to.be.true()
+    } catch (err: any) {
+      expect(err).to.not.exist()
+    }
+  })
+})
+
+describe('interface-blockstore (Main Thread OPFS Blockstore)', () => {
+  it('OPFS blockstore', async () => {
+    try {
+      interfaceBlockstoreTests({
+        async setup () {
+          const store = new OPFSMainThreadBlockstore('bs-' + Date.now())
+          await store.open()
+          return store
+        },
+        async teardown (store: OPFSMainThreadBlockstore) {
+          await store.close()
+        }
+      })
+      expect(true).to.be.true()
+    } catch (err: any) {
+      expect(err).to.not.exist()
+    }
+  })
+})
+
+describe('interface-blockstore (WebWorker backed OPFS Blockstore)', () => {
+  it('OPFS blockstore', async () => {
+    try {
+      interfaceBlockstoreTests({
+        async setup () {
+          const store = new OPFSWebWorkerBlockstore('bs-' + Date.now())
+          await store.open()
+          return store
+        },
+        async teardown (store: OPFSWebWorkerBlockstore) {
+          await store.close()
         }
       })
       expect(true).to.be.true()


### PR DESCRIPTION
Some contexts (e.g. service workers) do not support web workers, so when they are not supported, fall back to running OPFS operations asynchronously in the main thread.